### PR TITLE
actions: version bumps (fixes #9)

### DIFF
--- a/.github/workflows/send_data.yml
+++ b/.github/workflows/send_data.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: sshagent
-        uses: webfactory/ssh-agent@v0.5.2
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -35,7 +35,7 @@ jobs:
           python main.py
 
       - name: sshagent
-        uses: webfactory/ssh-agent@v0.5.2
+        uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
@@ -53,7 +53,7 @@ jobs:
           scp ./web/*.html root@maps.media.mit.edu:/root/map/
 
       - name: Upload Result
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: result
           path: data/*


### PR DESCRIPTION
fixes #9

also soon: actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact